### PR TITLE
fixed bug in copying apps

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -51,7 +51,7 @@ action :install do
 
     case new_resource.type
     when "app"
-      "rsync --recursive --links --perms --executability --owner --group --times '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
+      execute "rsync --recursive --links --perms --executability --owner --group --times '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
         user new_resource.owner if new_resource.owner
       end
 

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -51,7 +51,7 @@ action :install do
 
     case new_resource.type
     when "app"
-      execute "rsync --recursive --links --perms --executability --owner --group --times '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
+      execute "rsync --force --recursive --links --perms --executability --owner --group --times '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
         user new_resource.owner if new_resource.owner
       end
 

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -51,7 +51,7 @@ action :install do
 
     case new_resource.type
     when "app"
-      execute "cp -R '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
+      "rsync --recursive --links --perms --executability --owner --group --times '/Volumes/#{volumes_dir}/#{new_resource.app}.app' '#{new_resource.destination}'" do
         user new_resource.owner if new_resource.owner
       end
 


### PR DESCRIPTION
When overwriting an app with a new version that uses symlinks, for example Skype or Xcode, errors were reported about overwriting non-directories with directories.  Passing -L flag to cp would result in a 'too many symlinks' error.  Using rsync fixes all of this.

Fixes #COOK-3389
