### PR TITLE
[COOK-3302] Fix hdiutil detach failure due to cfprefsd

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -27,7 +27,6 @@ end
 action :install do
   unless @dmgpkg.installed
 
-    osx_majorver = node['platform_version'].split('.')[0,2].join()
     volumes_dir = new_resource.volumes_dir ? new_resource.volumes_dir : new_resource.app
     dmg_name = new_resource.dmg_name ? new_resource.dmg_name : new_resource.app
     dmg_file = "#{Chef::Config[:file_cache_path]}/#{dmg_name}.dmg"
@@ -63,7 +62,7 @@ action :install do
     when "mpkg", "pkg"
       execute "sudo installer -pkg '/Volumes/#{volumes_dir}/#{new_resource.app}.#{new_resource.type}' -target /" do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images
-        environment( {'__CFPREFERENCES_AVOID_DAEMON' => '1'} ) if osx_majorver.to_i >= 108
+        environment( {'__CFPREFERENCES_AVOID_DAEMON' => '1'} ) if Chef::Version::Platform.new(node['platform_version']) >= Chef::Version::Platform.new("10.8")
       end
     end
 

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -67,7 +67,7 @@ action :install do
       end
     end
 
-    execute "hdiutil detach '/Volumes/#{volumes_dir}'"
+    execute "hdiutil detach '/Volumes/#{volumes_dir}' || hdiutil detach '/Volumes/#{volumes_dir}' -force"
   end
 end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3302
- Try to set __CFPREFERENCES_AVOID_DAEMON=1 if on Mountain Lion or
  greater to avoid cfprefsd launch (doesn't seem to obey all the time)
- Force unmount dmg if detach fails the first time
