### PR TITLE
[COOK-2672] read output into memory before printing to avoid pager

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -45,7 +45,7 @@ action :install do
         software_license_agreement = system("hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}' | grep -q 'Software License Agreement: true'")
         raise "Requires EULA Acceptance; add 'accept_eula true' to package resource" if software_license_agreement && !new_resource.accept_eula
         accept_eula_cmd = new_resource.accept_eula ? "echo Y |" : ""
-        system "#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}'"
+        puts `#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}'`
       end
       not_if "hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
     end


### PR DESCRIPTION
only side effect I can think of offhand is this will fail when the license file is larger than available memory
