### PR TITLE
[COOK-3934] use use_inline_resources only if defined

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 def load_current_resource
   @dmgpkg = Chef::Resource::DmgPackage.new(new_resource.name)


### PR DESCRIPTION
_use_inline_resources_ isn't available in all versions of chef. This fixes it just to support an older version of Chef.
- https://tickets.opscode.com/browse/COOK-3934
