### PR TITLE
[COOK-4285] Accept long EULAs

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -49,7 +49,7 @@ action :install do
         cmd = shell_out("hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}' | grep -q 'Software License Agreement: true'")
         software_license_agreement = (cmd.exitstatus == 0)
         fail "Requires EULA Acceptance; add 'accept_eula true' to package resource" if software_license_agreement && !new_resource.accept_eula
-        accept_eula_cmd = new_resource.accept_eula ? 'echo Y |' : ''
+        accept_eula_cmd = new_resource.accept_eula ? 'echo Y | PAGER=true' : ''
         shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -quiet")
       end
       not_if "hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"


### PR DESCRIPTION
By setting `PAGER` to `true` it bypasses the EULA to be shown.
So user interaction is no longer required for dmg's with a long EULA.

This is a fix for [COOK-4285](https://tickets.opscode.com/browse/COOK-4285) which actually never was fixed because of a faulty merge.
