### PR TITLE
Use pkgutil '--pkg-info' instead of '--pkgs'.

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -82,7 +82,7 @@ def installed?
   if ::File.directory?("#{new_resource.destination}/#{new_resource.app}.app")
     Chef::Log.info "Already installed; to upgrade, remove \"#{new_resource.destination}/#{new_resource.app}.app\""
     true
-  elsif shell_out("pkgutil --pkgs='#{new_resource.package_id}'").exitstatus == 0
+  elsif shell_out("pkgutil --pkg-info '#{new_resource.package_id}'").exitstatus == 0
     Chef::Log.info "Already installed; to upgrade, try \"sudo pkgutil --forget '#{new_resource.package_id}'\""
     true
   else


### PR DESCRIPTION
`pkgutil --pkgs='PACKAGE_ID'` treats `PACKAGE_ID` like a regular expression. The dmg cookbook documentation implies that the value of `PACKAGE_ID` is a literal package id, not a regular expression. In this case, it makes more sense to use `pkgutil --pkg-info 'PACKAGE_ID'`, which matches on the literal package id.
