### PR TITLE
Drop '-quiet' switch

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -54,7 +54,7 @@ action :install do
         software_license_agreement = cmd.exitstatus == 0
         raise "Requires EULA Acceptance; add 'accept_eula true' to package resource" if software_license_agreement && !new_resource.accept_eula
         accept_eula_cmd = new_resource.accept_eula ? 'echo Y | PAGER=true' : ''
-        shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -mountpoint '/Volumes/#{volumes_dir}' -quiet")
+        shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -mountpoint '/Volumes/#{volumes_dir}'")
       end
       not_if "hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
     end


### PR DESCRIPTION
Due to whatever exactly is going on [here](https://github.com/chef/mixlib-shellout/issues/100) there are currently at least some packages that fail to install under a Chef packaged with the latest mixlib-shellout. Not sure what'll end up happening there, but this could be a potential workaround just to get things going again here.

The command doesn't seem all that verbose without the -quiet switch, unless folks have a strong opinion on keeping it...?
