### PR TITLE
Fixed pkg,mpkg installation when it was using mounted app name while …

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -54,7 +54,7 @@ action :install do
         software_license_agreement = (cmd.exitstatus == 0)
         raise "Requires EULA Acceptance; add 'accept_eula true' to package resource" if software_license_agreement && !new_resource.accept_eula
         accept_eula_cmd = new_resource.accept_eula ? 'echo Y | PAGER=true' : ''
-        shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -quiet")
+        shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -mountpoint '/Volumes/#{volumes_dir}' -quiet")
       end
       not_if "hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
     end
@@ -70,7 +70,7 @@ action :install do
         ignore_failure true
       end
     when 'mpkg', 'pkg'
-      execute "sudo installer -pkg '/Volumes/#{volumes_dir}/#{new_resource.app}.#{new_resource.type}' -target /" do
+      execute "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target /" do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images
         environment('__CFPREFERENCES_AVOID_DAEMON' => '1') if Gem::Version.new(node['platform_version']) >= Gem::Version.new('10.8')
       end


### PR DESCRIPTION
### Description

Some apps are failing on installation, Adobe Reader DC for example, so this PR provide a solution.
Fixed pkg,mpkg installation when it was using mounted app name while it was actually mounted under different name for some applications.
Perhaps .app installation block should also be customized.
### Issues Resolved
- pkg, mpkg installation.
