### PR TITLE
Fix #29, incompatibility with Chef 13

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -22,7 +22,7 @@ include Chef::Mixin::ShellOut
 use_inline_resources if defined?(use_inline_resources)
 
 def load_current_resource
-  @dmgpkg = Chef::Resource::DmgPackage.new(new_resource.name)
+  @dmgpkg = Chef::Resource.resource_for_node(:dmg_package, node).new(new_resource.name)
   @dmgpkg.app(new_resource.app)
   Chef::Log.debug("Checking for application #{new_resource.app}")
   @dmgpkg.installed(installed?)


### PR DESCRIPTION

### Description

Per the Chef 13 [release notes](https://docs.chef.io/release_notes.html) LWRP resources no longer get constant names.

### Issues Resolved

This error when run under Chef 13:

```
================================================================================
Error executing action `install` on resource 'dmg_package[Chef Development Kit]'
================================================================================

NameError
---------
uninitialized constant Chef::Resource::DmgPackage
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
~New functionality includes testing~
~New functionality has been documented in the README if applicable~
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jonathan Hartman <j@p4nt5.com>
