### PR TITLE
Adds allow_untrusted property for older packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,3 +23,5 @@ platforms:
 suites:
   - name: default
     run_list: test::default
+  - name: untrusted
+    run_list: test::untrusted

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Optionally, the LWRP can install an "mpkg" or "pkg" package using installer(8).
 - `dmg_passphrase` - Specify a passphrase to use to unencrypt the dmg while mounting.
 - `accept_eula` - Specify whether to accept the EULA. Certain dmgs require acceptance of EULA before mounting. Can be true or false, defaults to false.
 - `headers` - Allows custom HTTP headers (like cookies) to be set on the remote_file resource.
+- `allow_untrusted` - Allows packages with untrusted certs to be installed.
 
 #### Examples
 

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -89,7 +89,7 @@ action :install do
       end
     when 'mpkg', 'pkg'
       install_cmd = "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target /" 
-      install_cmd += ' -allowUntrusted' if allow_untrusted
+      install_cmd += ' -allowUntrusted' if new_resource.allow_untrusted
 
       execute install_cmd do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -88,8 +88,10 @@ action :install do
         ignore_failure true
       end
     when 'mpkg', 'pkg'
-      allow_untrusted_cmd = allow_untrusted ? '-allowUntrusted' : ''
-      execute "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target / #{allow_untrusted_cmd}" do
+      install_cmd = "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target /" 
+      install_cmd += '-allowUntrusted' if allow_untrusted
+
+      execute install_cmd do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images
         environment('__CFPREFERENCES_AVOID_DAEMON' => '1')
       end

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -88,8 +88,10 @@ action :install do
         ignore_failure true
       end
     when 'mpkg', 'pkg'
-      allow_untrusted_cmd = allow_untrusted ? '-allowUntrusted' : ''
-      execute "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target / #{allow_untrusted_cmd}" do
+      install_cmd = "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target /" 
+      install_cmd += ' -allowUntrusted' if allow_untrusted
+
+      execute install_cmd do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images
         environment('__CFPREFERENCES_AVOID_DAEMON' => '1')
       end

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -32,6 +32,7 @@ property :package_id, String
 property :dmg_passphrase, String
 property :accept_eula, [true, false], default: false
 property :headers, [Hash, nil], default: nil
+property :allow_untrusted, [true, false], default: false
 
 load_current_value do |new_resource|
   if ::File.directory?("#{new_resource.destination}/#{new_resource.app}.app")
@@ -87,7 +88,8 @@ action :install do
         ignore_failure true
       end
     when 'mpkg', 'pkg'
-      execute "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target /" do
+      allow_untrusted_cmd = allow_untrusted ? '-allowUntrusted' : ''
+      execute "installation_file=$(ls '/Volumes/#{volumes_dir}' | grep '.#{new_resource.type}$') && sudo installer -pkg \"/Volumes/#{volumes_dir}/$installation_file\" -target / #{allow_untrusted_cmd}" do
         # Prevent cfprefsd from holding up hdiutil detach for certain disk images
         environment('__CFPREFERENCES_AVOID_DAEMON' => '1')
       end

--- a/test/cookbooks/test/recipes/untrusted.rb
+++ b/test/cookbooks/test/recipes/untrusted.rb
@@ -1,0 +1,8 @@
+dmg_package 'virtualbox' do
+  app 'virtualbox'
+  source 'http://download.virtualbox.org/virtualbox/4.3.40/VirtualBox-4.3.40-110317-OSX.dmg'
+  checksum 'eb70fc0f36844ced6dc7deeb30397866fbaffb4a8dfb6071b047e943cae6a312'
+  type 'pkg'
+  accept_eula true
+  allow_untrusted true
+end

--- a/test/integration/untrusted/untrusted_spec.rb
+++ b/test/integration/untrusted/untrusted_spec.rb
@@ -1,0 +1,3 @@
+describe command('/usr/local/bin/VBoxManage') do
+  it { should exist }
+end


### PR DESCRIPTION
Signed-off-by: Melissa Fritcher <mfritcher@us.ibm.com>

### Description
This change adds a allow_untrusted property to the dmg_package resource to allow older packages to be installed. Defaults to false; 

### Issues Resolved

https://github.com/chef-cookbooks/dmg/issues/31 Being able to pass the -allowUntrusted flag to installer would be pretty helpful for older packages. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
